### PR TITLE
Update get command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Render Go text templates from the command line.
 
-    go get github.com/gomatic/renderizer
+    go get github.com/gomatic/renderizer/cmd/renderizer
 
 Supports providing top-level name/value pairs on the command line:
 


### PR DESCRIPTION
Existing 'go get' command is missing path to cmd subdirectory.