### PR TITLE
Added homebrew release to .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,7 +60,7 @@ brews:
     # GitHub/GitLab repository to push the formula to
     tap:
       owner: gomatic
-      name: renderizer-homebrew
+      name: homebrew-renderizer
       # Optionally a token can be provided, if it differs from the token provided to GoReleaser
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,3 +45,51 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+
+brews:
+  -
+    # Name template of the recipe
+    # Default to project name
+    name: renderizer
+
+    # GOARM to specify which 32-bit arm version to use if there are multiple versions
+    # from the build section. Brew formulas support atm only one 32-bit version.
+    # Default is 6 for all artifacts or each id if there a multiple versions.
+    goarm: 6
+
+    # GitHub/GitLab repository to push the formula to
+    tap:
+      owner: gomatic
+      name: renderizer-homebrew
+      # Optionally a token can be provided, if it differs from the token provided to GoReleaser
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+
+    url_template: "https://github.com/gomatic/renderizer/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+
+    # Git author used to commit to the repository.
+    # Defaults are shown.
+    commit_author:
+      name: goreleaserbot
+      email: nicerobot@users.noreply.github.com
+
+    # Folder inside the repository to put the formula.
+    # Default is the root folder.
+    folder: Formula
+
+    # Your app's homepage.
+    # Default is empty.
+    homepage: "https://github.com/gomatic/renderizer"
+
+    # Your app's description.
+    # Default is empty.
+    description: "CLI to render Go template text files based on command line parameters and/or a YAML"
+
+    # SPDX identifier of your app's license.
+    # Default is empty.
+    license: "GPL-3.0"
+
+    # Custom install script for brew.
+    # Default is 'bin.install "program"'.
+    install: |
+      bin.install "renderizer"
+      ...


### PR DESCRIPTION
# Description

- Added support for homebrew in the goreleaser config
- Homebrew tap will be released to `gomatic/homebrew-renderizer` in the `Forumula` folder

Hope this is helpful!